### PR TITLE
Added ubuntu.14.04-x64 as a runtime in project.json

### DIFF
--- a/src/ConfigUtil/project.json
+++ b/src/ConfigUtil/project.json
@@ -17,7 +17,8 @@
     "netcoreapp1.0": {}
   },
   "runtimes": {
-    "win8-x64": {}
+    "win8-x64": {},
+    "ubuntu.14.04-x64": {}
   },
   "buildOptions": {
     "emitEntryPoint": true,


### PR DESCRIPTION
Allows project to build on ubuntu 14.04. Should add other runtimes as well, or figure out a way to not have to specify a runtime?
