### PR TITLE
Added commands to turn telemetry off for the build script.

### DIFF
--- a/build_release.sh
+++ b/build_release.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 (
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+echo Setting DOTNET_CLI_TELEMETRY_OPTOUT=${DOTNET_CLI_TELEMETRY_OPTOUT}
 cd $(dirname $0)
 cd src/ConfigUtil
 dotnet restore


### PR DESCRIPTION
This is done as a courtesy to those that might not want telemetry turned on when building OSVR-Config, and _might_ improve reliability of builds in CI.
