### PR TITLE
Added utility to get the cross-platform name of executables.

### DIFF
--- a/src/ConfigUtil/Common/OSExeUtil.cs
+++ b/src/ConfigUtil/Common/OSExeUtil.cs
@@ -16,20 +16,20 @@
 /// limitations under the License.
 /// </copyright>
 /// 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using ConfigUtil.Common;
+using System.Runtime.InteropServices;
+using System.IO;
 
-namespace ConfigUtil.Models
+namespace ConfigUtil.Common
 {
-    public static class TrackerViewer
+    public static class OSExeUtil
     {
-        public static void Start(IEnumerable<string> paths, string serverPath)
+        public static string PlatformSpecificExeName(string normalizedName)
         {
-            var trackerViewerExeName = OSExeUtil.PlatformSpecificExeName("OSVRTrackerView");
-            var trackerViewerPath = System.IO.Path.Combine(serverPath, trackerViewerExeName);
-            Process.Start(trackerViewerPath, String.Join(" ", paths));
+            if(RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return Path.ChangeExtension(normalizedName, "exe");
+            }
+            return normalizedName;
         }
     }
 }

--- a/src/ConfigUtil/Models/DirectMode.cs
+++ b/src/ConfigUtil/Models/DirectMode.cs
@@ -17,6 +17,7 @@
 /// </copyright>
 /// 
 using System.Diagnostics;
+using ConfigUtil.Common;
 
 namespace ConfigUtil.Models
 {
@@ -24,17 +25,23 @@ namespace ConfigUtil.Models
     {
         public static void Disable(string serverPath)
         {
-            var disableDirectModePath = System.IO.Path.Combine(serverPath, "DisableOSVRDirectMode.exe");
-            var disableDirectModePathAMD = System.IO.Path.Combine(serverPath, "DisableOSVRDirectModeAMD.exe");
+            var disableDirectModeFileName = OSExeUtil.PlatformSpecificExeName("DisableOSVRDirectMode");
+            var disableDirectModePath = System.IO.Path.Combine(serverPath, disableDirectModeFileName);
             Process.Start(disableDirectModePath);
+
+            var disableDirectModeAMDFileName = OSExeUtil.PlatformSpecificExeName("DisableOSVRDirectModeAMD");
+            var disableDirectModePathAMD = System.IO.Path.Combine(serverPath, disableDirectModeAMDFileName);
             Process.Start(disableDirectModePathAMD);
         }
 
         public static void Enable(string serverPath)
         {
-            var enableDirectModePath = System.IO.Path.Combine(serverPath, "EnableOSVRDirectMode.exe");
-            var enableDirectModePathAMD = System.IO.Path.Combine(serverPath, "EnableOSVRDirectModeAMD.exe");
+            var enableDirectModeFileName = OSExeUtil.PlatformSpecificExeName("EnableOSVRDirectMode");
+            var enableDirectModePath = System.IO.Path.Combine(serverPath, enableDirectModeFileName);
             Process.Start(enableDirectModePath);
+
+            var enableDirectModeAMDFileName = OSExeUtil.PlatformSpecificExeName("EnableOSVRDirectModeAMD");
+            var enableDirectModePathAMD = System.IO.Path.Combine(serverPath, enableDirectModeAMDFileName);
             Process.Start(enableDirectModePathAMD);
         }
     }

--- a/src/ConfigUtil/Models/OSVRServer.cs
+++ b/src/ConfigUtil/Models/OSVRServer.cs
@@ -19,6 +19,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using ConfigUtil.Common;
 
 namespace ConfigUtil.Models
 {
@@ -26,7 +27,8 @@ namespace ConfigUtil.Models
     {
         public static void Start(string serverPath)
         {
-            var osvrServerExe = Path.Combine(serverPath, "osvr_server.exe");
+            var osvrServerExeFileName = OSExeUtil.PlatformSpecificExeName("osvr_server");
+            var osvrServerExe = Path.Combine(serverPath, osvrServerExeFileName);
             var startInfo = new ProcessStartInfo();
             startInfo.FileName = osvrServerExe;
             startInfo.WorkingDirectory = serverPath;


### PR DESCRIPTION
Part of a series of fixes for https://github.com/OSVR/OSVR-Config/issues/32
